### PR TITLE
Clarify where to get the API tokens from

### DIFF
--- a/frontend-engineer/README.md
+++ b/frontend-engineer/README.md
@@ -7,7 +7,9 @@ all senders. Something like this:
 The assets and additional documentation can be found in the **assets** folder.
 
 For this, we have prepared a simple API which receives new messages in a `POST` endpoint
-and lists all messages reverse chronological order in a `GET` endpoint:
+and lists all messages reverse chronological order in a `GET` endpoint. Please use your personal `YOUR_AWESOME_UNIQUE_TOKEN`.
+
+You should've gotten the `YOUR_AWESOME_UNIQUE_TOKEN` via email. If not, please do not hesitate to get in touch and we'll provide you one.
 
 #### List all messages
 ```shell script

--- a/web-developer/README.md
+++ b/web-developer/README.md
@@ -7,7 +7,9 @@ all senders. Something like this:
 The assets and additional documentation can be found in the **assets** folder.
 
 For this, we have prepared a simple API which receives new messages in a `POST` endpoint
-and lists all messages reverse chronological order in a `GET` endpoint:
+and lists all messages reverse chronological order in a `GET` endpoint. Please use your personal `YOUR_AWESOME_UNIQUE_TOKEN`.
+
+You should've gotten the `YOUR_AWESOME_UNIQUE_TOKEN` via email. If not, please do not hesitate to get in touch and we'll provide you one.
 
 #### List all messages
 ```shell script


### PR DESCRIPTION
Adds information that the API token for Chatty should've been received with the email or - if not provided by us for some reason - should be requested.